### PR TITLE
README should just redirect to course webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,54 +4,5 @@ This repository hosts the slides and materials for the
 
 The rendered slides are available [here](https://neuroinformatics.dev/course-behavioural-analysis/#/title-slide).
 
-## Overview
-This is an introductory course on analysing animal behaviour from video data. The course covers:
-
-- Overview of animal tracking methods and terminology.
-- **Pose estimation and tracking with [SLEAP](https://sleap.ai/)**. This includes hands-on practice with training a pose estimation model, evaluating its performance, and using it to predict pose tracks in new videos.
-- **Analysing pose tracks with [movement](https://movement.neuroinformatics.dev/)**. This includes loading the predicted pose tracks in Python, filtering and smoothing them, computing kinematic variables, and visualising the results.
-- **Extracting behavioural syllables with [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)**.
-
-## Instructors
-* [Niko Sirmpilatze ](https://github.com/niksirbi)
-* [Chang Huan Lo](https://github.com/lochhh)
-* [Sofía Miñano](https://github.com/sfmig)
-
-## Prerequisites
-
-### Hardware Requirements
-
-This is a hands-on course, so **please bring your own laptop and charger**. A mouse is recommended but not essential. A dedicated GPU is not required but will be helpful.
-
-### General Software Requirements
-
-> [!Note]
-> If you are attending the entire [General Software Skills for Systems Neuroscience](https://software-skills.neuroinformatics.dev/courses/software-skills.html) course, you will have already installed the general software requirements during Day 1 and may skip this section.
-
-- An IDE for Python programming. We recommend one of the following:
-  - [Visual Studio Code](https://code.visualstudio.com/) with the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-  - [PyCharm](https://www.jetbrains.com/pycharm/)
-  - [JupyterLab](https://jupyter.org/install)
-
-- A working `conda` (or `mamba`) installation. If you don't have it, install via [Miniforge](https://github.com/conda-forge/miniforge).
-- A working [Git](https://git-scm.com/) installation.
-
-### Specific Software Requirements
-
-> [!Note]
-> Only proceed with these installations after completing the above general software requirements.
-
-You will need to pre-install two different `conda` environments for the practical exercises. Create them as follows:
-
-1. [**SLEAP**](https://sleap.ai/): Use the [conda package method](https://sleap.ai/installation.html#conda-package) from the SLEAP installation guide. You may use `conda` instead of `mamba` in the installation command. If your machine lacks an NVIDIA GPU, that's fine; for this course, you just need to be able to launch the SLEAP GUI using `sleap-label`.
-2. [**Keypoint-MoSeq**](https://keypoint-moseq.readthedocs.io): Use the recommended [conda installation method](https://keypoint-moseq.readthedocs.io/en/latest/install.html#install-using-conda).
-
-You should now have two new conda environments called `sleap` and `keypoint_moseq`. To view all your conda environments, run `conda env list`.
-
-### Sample Data
-
-Download the sample data for this course from [Dropbox](https://www.dropbox.com/scl/fo/ey7b6yrqax2olqyv1th7j/h?rlkey=u4wh2gxtbbn4g5o3s55zbx6pp&st=zolupk4i&dl=0). Click "Download" to get the `behav-analysis-course.zip` archive and unzip it.
-
-Alternatively, if you have access to the SWC's `ceph` filesystem, find the dataset at `/ceph/scratch/neuroinformatics-dropoff/behav-analysis-course`. To mount `ceph` on your laptop, follow the [instructions on the SWC wiki](https://wiki.ucl.ac.uk/display/SSC/Storage%3A+Ceph). Note: You must be connected to the SWC network to access the wiki and mount `ceph`.
-
-Ensure you copy the data to a convenient location on your laptop.
+See the [course webpage](https://software-skills.neuroinformatics.dev/courses/video-analysis.html) for 
+more information on content and pre-requisites.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Video-based analysis of animal behaviour
 This repository hosts the slides and materials for the
-[behavioural analysis course](https://software-skills.neuroinformatics.dev/courses/video-analysis.html) taking place annualy at the [Sainsbury Wellcome Centre (SWC)](https://www.sainsburywellcome.org/web/).
+[behavioural analysis course](https://software-skills.neuroinformatics.dev/courses/video-analysis.html) taking place annually at the [Sainsbury Wellcome Centre (SWC)](https://www.sainsburywellcome.org/web/).
 
 The rendered slides are available [here](https://neuroinformatics.dev/course-behavioural-analysis/#/title-slide).
 

--- a/README.md
+++ b/README.md
@@ -1,78 +1,57 @@
 # Video-based analysis of animal behaviour
 This repository hosts the slides and materials for the
-[behavioural analysis course](https://software-skills.neuroinformatics.dev/courses/video-analysis.html) taking place at the [Sainsbury Wellcome Centre (SWC)](https://www.sainsburywellcome.org/web/)
-in November 2023.
+[behavioural analysis course](https://software-skills.neuroinformatics.dev/courses/video-analysis.html) taking place annualy at the [Sainsbury Wellcome Centre (SWC)](https://www.sainsburywellcome.org/web/).
 
 The rendered slides are available [here](https://neuroinformatics.dev/course-behavioural-analysis/#/title-slide).
 
 ## Overview
 This is an introductory course on analysing animal behaviour from video data. The course covers:
 
-- Motivation
-- Overview of animal tracking methods and terminology
-- Pose estimation and tracking
-  - Overview of existing tools
-  - Labeling animal body parts
-  - Training a model
-  - Predicting poses
-  - Evaluating performance
-- Analysing pose tracks with Python
-  - Loading and saving data
-  - Filtering/smoothing
-  - Visualising tracks
-  - Time spent in regions of interest
+- Overview of animal tracking methods and terminology.
+- **Pose estimation and tracking with [SLEAP](https://sleap.ai/)**. This includes hands-on practice with training a pose estimation model, evaluating its performance, and using it to predict pose tracks in new videos.
+- **Analysing pose tracks with [movement](https://movement.neuroinformatics.dev/)**. This includes loading the predicted pose tracks in Python, filtering and smoothing them, computing kinematic variables, and visualising the results.
+- **Extracting behavioural syllables with [keypoint-moseq](https://keypoint-moseq.readthedocs.io/en/latest/index.html)**.
+
+## Instructors
+* [Niko Sirmpilatze ](https://github.com/niksirbi)
+* [Chang Huan Lo](https://github.com/lochhh)
+* [Sofía Miñano](https://github.com/sfmig)
 
 ## Prerequisites
-Make sure to follow these steps before the course starts. If you encounter any issues, please contact Niko Sirmpilatze via the SWC slack.
 
-### Set up your laptop with an IDE and conda
-This is a hands-on course, so make sure to bring your **own laptop and charger**.
-A dedicated GPU may make some exercises much more enjoyable, but is **not required**.
+### Hardware Requirements
 
-Make sure to have an IDE installed, for example:
-- [Visual Studio Code](https://code.visualstudio.com/)
-- [PyCharm](https://www.jetbrains.com/pycharm/)
-- [Jupyter Lab](https://jupyter.org/install)
+This is a hands-on course, so **please bring your own laptop and charger**. A mouse is recommended but not essential. A dedicated GPU is not required but will be helpful.
 
-If you don't already have `conda` set up on your computer, 
-you can do so via [miniconda](https://docs.conda.io/projects/miniconda/en/latest/).
+### General Software Requirements
 
-### Install [SLEAP](https://sleap.ai) in a conda environment
-We recommend reading the official [SLEAP installation guide](https://sleap.ai/installation.html).
-If you already have `conda` installed, you may skip the `mamba` installation steps outlined there.
-Instead, install the `libmamba-solver` for `conda`:
+> [!Note]
+> If you are attending the entire [General Software Skills for Systems Neuroscience](https://software-skills.neuroinformatics.dev/courses/software-skills.html) course, you will have already installed the general software requirements during Day 1 and may skip this section.
 
-```bash
-conda install -n base conda-libmamba-solver
-conda config --set solver libmamba
-```
-This will get you the much faster dependency resolution that `mamba` provides, without having to install `mamba` itself.
-From `conda` version 23.10 onwards (released in November 2023), `libmamba-solver` [is anyway the default](https://conda.org/blog/2023-11-06-conda-23-10-0-release/).
+- An IDE for Python programming. We recommend one of the following:
+  - [Visual Studio Code](https://code.visualstudio.com/) with the [Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
+  - [PyCharm](https://www.jetbrains.com/pycharm/)
+  - [JupyterLab](https://jupyter.org/install)
 
-After that, you can follow the [rest of the SLEAP installation guide](https://sleap.ai/installation.html#conda-package), substituting `conda` for `mamba` in the relevant commands.
+- A working `conda` (or `mamba`) installation. If you don't have it, install via [Miniforge](https://github.com/conda-forge/miniforge).
+- A working [Git](https://git-scm.com/) installation.
 
-**Windows and Linux**
-```bash
-conda create -y -n sleap -c conda-forge -c nvidia -c sleap -c anaconda sleap=1.3.1
-```
+### Specific Software Requirements
 
-**MacOS X (including Apple Silicon)**
-```bash
-conda create -y -n sleap -c conda-forge -c anaconda -c sleap sleap=1.3.1
-```
-If your machine doesn't include a GPU, you may ignore the [GPU support](https://sleap.ai/installation.html#gpu-support) section of the installation instructions.
+> [!Note]
+> Only proceed with these installations after completing the above general software requirements.
 
-__Note__
-We have chosen `v1.3.1` to ensure compatibility with the version of SLEAP installed on the SWC's HPC cluster, but more recent versions - e.g. `v1.3.3` - should work just as well.
+You will need to pre-install two different `conda` environments for the practical exercises. Create them as follows:
 
-### Get the sample data
-You can download the sample data for this course from 
-[DropBox](https://www.dropbox.com/scl/fo/ey7b6yrqax2olqyv1th7j/h?rlkey=u4wh2gxtbbn4g5o3s55zbx6pp&st=zolupk4i&dl=0).
-Please click on "Download" to get the entire `behav-analysis-course.zip` archive, and unzip it.
+1. [**SLEAP**](https://sleap.ai/): Use the [conda package method](https://sleap.ai/installation.html#conda-package) from the SLEAP installation guide. You may use `conda` instead of `mamba` in the installation command. If your machine lacks an NVIDIA GPU, that's fine; for this course, you just need to be able to launch the SLEAP GUI using `sleap-label`.
+2. [**Keypoint-MoSeq**](https://keypoint-moseq.readthedocs.io): Use the recommended [conda installation method](https://keypoint-moseq.readthedocs.io/en/latest/install.html#install-using-conda).
 
-Alternatively, if you have access to the SWC's `ceph` filesystem, you can find the dataset in `/ceph/scratch/neuroinformatics-dropoff/behav-analysis-course`. To mount `ceph` on your laptop, follow the [relevant instructions on the SWC wiki](https://wiki.ucl.ac.uk/display/SSC/Storage%3A+Ceph). You need to be connected to the SWC network both to read the wiki and to mount `ceph`.
+You should now have two new conda environments called `sleap` and `keypoint_moseq`. To view all your conda environments, run `conda env list`.
 
-No matter how you got the data, make sure to copy it to a convenient location on your laptop.
+### Sample Data
 
-### Optional: bring your own data
-Optionally, you may bring along any animal videos that you would like to analyse. This could simply be a video of your pet, or of the fox you spotted in your garden last night. Preferably, the videos should be in either `.mp4` or `.avi` format.
+Download the sample data for this course from [Dropbox](https://www.dropbox.com/scl/fo/ey7b6yrqax2olqyv1th7j/h?rlkey=u4wh2gxtbbn4g5o3s55zbx6pp&st=zolupk4i&dl=0). Click "Download" to get the `behav-analysis-course.zip` archive and unzip it.
+
+Alternatively, if you have access to the SWC's `ceph` filesystem, find the dataset at `/ceph/scratch/neuroinformatics-dropoff/behav-analysis-course`. To mount `ceph` on your laptop, follow the [instructions on the SWC wiki](https://wiki.ucl.ac.uk/display/SSC/Storage%3A+Ceph). Note: You must be connected to the SWC network to access the wiki and mount `ceph`.
+
+Ensure you copy the data to a convenient location on your laptop.


### PR DESCRIPTION
The README was displaying some duplicate information to  the course webpage.  To avoid the need for keeping both up-to-date, the README now points to the course website for more info. This PR should be reviewed in tandem with https://github.com/neuroinformatics-unit/software-skills/pull/62
