### PR TITLE
Fix EPM_syllables.ipynb

### DIFF
--- a/notebooks/EPM_syllables.ipynb
+++ b/notebooks/EPM_syllables.ipynb
@@ -44,15 +44,15 @@
     "\n",
     "This last command will create a conda environment called `keypoint_moseq`. We can activate this environment by running:\n",
     "```bash\n",
-    "conda activate keypoint-moseq\n",
+    "conda activate keypoint_moseq\n",
     "```\n",
     "\n",
-    "Optionally, to display interactive plots in the notebook, we can install the `ipympl` package in the `keypoint-moseq` environment:\n",
+    "Optionally, to display interactive plots in the notebook, we can install the `ipympl` package in the `keypoint_moseq` environment:\n",
     "```bash\n",
     "pip install ipympl \n",
     "```\n",
     "\n",
-    "Once all required packages are installed, you can re-open this notebook and select the `keypoint-moseq` kernel to get started."
+    "Once all required packages are installed, you can re-open this notebook and select the `keypoint_moseq` kernel to get started."
    ]
   },
   {


### PR DESCRIPTION
The command to activate the environment was wrong; it said `conda activate keypoint-moseq` but should be `conda activate keypoint_moseq`
